### PR TITLE
Make parseReserve import more explicit

### DIFF
--- a/src/classes/action.ts
+++ b/src/classes/action.ts
@@ -40,7 +40,7 @@ import {
 } from "../instructions";
 import { U64_MAX, WAD } from "./constants";
 import BigNumber from "bignumber.js";
-import { parseReserve } from "..";
+import { parseReserve } from "../state";
 import axios from "axios";
 
 export const POSITION_LIMIT = 6;


### PR DESCRIPTION
Hi, under certain conditions, the import to `parseReserve` being `..` is causing errors

In our case (just normal bundling through rollup) we weren't able to use any instructions (like withdraw) that are depending on `parseReserve`. The transpiled javascript object (`__1`) ended up undefined, so the call to `parseReserve` fails

<img width="669" alt="ScreenShot 1" src="https://user-images.githubusercontent.com/688326/175514255-5301d8b5-612d-4d00-bc94-ed161409b926.png">
 
<img width="1032" alt="ScreenShot 2" src="https://user-images.githubusercontent.com/688326/175514333-f9c80215-3bd0-4d90-bd9f-e9df1b1968de.png">

After making the import more explicit everything is fine again, transpiled now looks like this:

```ts
const parsedData = (_a = (0, state_1.parseReserve)(new web3_js_1.PublicKey(this.reserve.address), buffer)) === null || _a === void 0 ? void 0 : _a.info;
```

Probably an edge case in the handling of `..` for imports