### PR TITLE
BN equality bug

### DIFF
--- a/src/classes/action.ts
+++ b/src/classes/action.ts
@@ -627,7 +627,7 @@ export class SolendAction {
 
     this.lendingIxs.push(
       withdrawObligationCollateralAndRedeemReserveLiquidity(
-        this.amount === new BN(U64_MAX)
+        this.amount.eq(new BN(U64_MAX))
           ? this.amount
           : new BN(
               new BigNumber(this.amount.toString())
@@ -812,7 +812,7 @@ export class SolendAction {
     if (
       this.obligationAccountInfo &&
       action === "repay" &&
-      this.amount === new BN(U64_MAX)
+      this.amount.eq(new BN(U64_MAX))
     ) {
       const buffer = await this.connection.getAccountInfo(
         new PublicKey(this.reserve.address),


### PR DESCRIPTION
`===` checks for object reference equality, which is probably not what you want

```
node
> const BN = require("bn.js");
undefined
> new BN(0) === new BN(0);
false
> new BN(0).eq(new BN(0))
true
```